### PR TITLE
test improvements + MANIFEST missing files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,8 @@
+include Makefile
+include tox.ini
 include LICENSE
 include doc/*.rst
 include doc/conf.py
 include doc/Makefile
+recursive-include examples *.py
+recursive-include test *.py

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 import sys
 from setuptools import setup, find_packages
 
-verstr = "1.0.0"
+verstr = "1.0.1"
 docstr = """
 ``txaio`` is a helper library for writing code that runs unmodified on
 both Twisted and asyncio.

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -1,0 +1,26 @@
+import pytest
+import txaio
+
+from util import run_once
+
+
+def test_illegal_args():
+    try:
+        txaio.create_future(result=1, error=RuntimeError("foo"))
+        assert False
+    except ValueError as e:
+        pass
+
+def test_create_result():
+    f = txaio.create_future(result='foo')
+    if txaio.using_twisted:
+        assert f.called
+    else:
+        assert f.done()
+
+def test_create_error():
+    f = txaio.create_future(error=RuntimeError("test"))
+    if txaio.using_twisted:
+        assert f.called
+    else:
+        assert f.done()

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -1,15 +1,13 @@
-import pytest
 import txaio
-
-from util import run_once
 
 
 def test_illegal_args():
     try:
         txaio.create_future(result=1, error=RuntimeError("foo"))
         assert False
-    except ValueError as e:
+    except ValueError:
         pass
+
 
 def test_create_result():
     f = txaio.create_future(result='foo')
@@ -17,6 +15,7 @@ def test_create_result():
         assert f.called
     else:
         assert f.done()
+
 
 def test_create_error():
     f = txaio.create_future(error=RuntimeError("test"))

--- a/test/test_imports.py
+++ b/test/test_imports.py
@@ -1,0 +1,38 @@
+import pytest
+
+
+def test_use_twisted():
+    pytest.importorskip('twisted')
+
+    import txaio
+    txaio.use_twisted()
+    assert txaio.using_twisted
+    assert not txaio.using_asyncio
+
+
+def test_use_twisted_no_twisted():
+    # make sure we DO NOT have Twisted installed
+    try:
+        import twisted  # noqa
+        return
+    except ImportError:
+        pass  # no Twisted
+
+    import txaio
+    try:
+        txaio.use_twisted()
+        assert "Should have gotten ImportError"
+    except ImportError:
+        pass
+
+    assert not txaio.using_twisted
+    assert txaio.using_asyncio
+
+
+def test_use_asyncio():
+    pytest.importorskip('asyncio')
+
+    import txaio
+    txaio.use_asyncio()
+    assert txaio.using_asyncio
+    assert not txaio.using_twisted

--- a/txaio/__init__.py
+++ b/txaio/__init__.py
@@ -73,26 +73,31 @@ __all__ = (
 
 def use_twisted():
     from txaio import tx
+    _use_framework(tx)
     import txaio
     txaio.using_twisted = True
     txaio.using_asyncio = False
-    for method_name in __all__:
-        if method_name in ['use_twisted', 'use_asyncio']:
-            continue
-        twisted_method = getattr(tx, method_name)
-        setattr(txaio, method_name, twisted_method)
 
 
 def use_asyncio():
     from txaio import aio
+    _use_framework(aio)
     import txaio
     txaio.using_twisted = False
     txaio.using_asyncio = True
+
+
+def _use_framework(module):
+    """
+    Internal helper, to set this modules methods to a specified
+    framework helper-methods.
+    """
+    import txaio
     for method_name in __all__:
         if method_name in ['use_twisted', 'use_asyncio']:
             continue
-        twisted_method = getattr(aio, method_name)
-        setattr(txaio, method_name, twisted_method)
+        setattr(txaio, method_name,
+                getattr(module, method_name))
 
 
 try:

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -108,25 +108,25 @@ class FailedFuture(IFailedFuture):
 # API methods for txaio, exported via the top-level __init__.py
 
 
-def create_future():
-    return Future()
+def create_future(result=None, error=None):
+    if result is not None and error is not None:
+        raise ValueError("Cannot have both result and error.")
 
-
-def create_future_success(result):
     f = Future()
-    f.set_result(result)
+    if result is not None:
+        resolve(f, result)
+    elif error is not None:
+        reject(f, error)
     return f
 
 
+def create_future_success(result):
+    return create_future(result=result)
+
+
 def create_future_error(error=None):
-    if error is None:
-        error = create_failure()
-    elif isinstance(error, Exception):
-        error = FailedFuture(type(error), error, None)
-    else:
-        assert isinstance(error, IFailedFuture)
-    f = Future()
-    f.set_exception(error.value)
+    f = create_future()
+    reject(f, error)
     return f
 
 


### PR DESCRIPTION
This bumps the version to 1.0.1 due to missing test/* files in the resulting tarball and consolidates and tests the use_twisted() vs. use_asyncio() calls