### PR TITLE
default arg for resolve() in asyncio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 import sys
 from setuptools import setup, find_packages
 
-verstr = "1.0.2"
+verstr = "1.0.3"
 docstr = """
 ``txaio`` is a helper library for writing code that runs unmodified on
 both Twisted and asyncio.

--- a/test/test_callback.py
+++ b/test/test_callback.py
@@ -28,6 +28,18 @@ import txaio
 
 from util import run_once
 
+def test_default_resolve():
+    f = txaio.create_future()
+    results = []
+    def cb(f):
+        results.append(f)
+    txaio.add_callbacks(f, cb, None)
+    txaio.resolve(f)
+
+    run_once()
+
+    assert len(results) == 1
+    assert results[0] is None
 
 def test_callback():
     f = txaio.create_future()

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -151,7 +151,7 @@ def call_later(delay, fun, *args, **kwargs):
     return config.loop.call_later(delay, real_call)
 
 
-def resolve(future, result):
+def resolve(future, result=None):
     future.set_result(result)
 
 


### PR DESCRIPTION
The twisted implementation includes a default value (None) for the resolve() method, but the asyncio implemtation does not. This fixes that, adds a unit-test and bumps the version.

Needed to fix https://github.com/tavendo/AutobahnPython/issues/445