### PR TITLE
correct as_future() operation on methods returning None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 import sys
 from setuptools import setup, find_packages
 
-verstr = "1.0.3"
+verstr = "1.0.4"
 docstr = """
 ``txaio`` is a helper library for writing code that runs unmodified on
 both Twisted and asyncio.

--- a/test/test_as_future.py
+++ b/test/test_as_future.py
@@ -59,6 +59,35 @@ def test_as_future_immediate():
     assert calls[0] == ((1, 2, 3), dict(key='word'))
 
 
+def test_as_future_immediate_none():
+    '''
+    Returning None immediately from as_future
+    '''
+    errors = []
+    results = []
+    calls = []
+
+    def method(*args, **kw):
+        calls.append((args, kw))
+        return None
+    f = txaio.as_future(method, 1, 2, 3, key='word')
+
+    def cb(x):
+        results.append(x)
+
+    def errback(f):
+        errors.append(f)
+
+    txaio.add_callbacks(f, cb, errback)
+
+    run_once()
+
+    assert len(results) == 1
+    assert len(errors) == 0
+    assert results[0] is None
+    assert calls[0] == ((1, 2, 3), dict(key='word'))
+
+
 def test_as_future_coroutine():
     '''
     call a coroutine (asyncio)

--- a/test/test_callback.py
+++ b/test/test_callback.py
@@ -28,9 +28,11 @@ import txaio
 
 from util import run_once
 
+
 def test_default_resolve():
     f = txaio.create_future()
     results = []
+
     def cb(f):
         results.append(f)
     txaio.add_callbacks(f, cb, None)
@@ -40,6 +42,7 @@ def test_default_resolve():
 
     assert len(results) == 1
     assert results[0] is None
+
 
 def test_callback():
     f = txaio.create_future()

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -108,14 +108,17 @@ class FailedFuture(IFailedFuture):
 # API methods for txaio, exported via the top-level __init__.py
 
 
-def create_future(result=None, error=None):
-    if result is not None and error is not None:
+_unspecified = object()
+
+
+def create_future(result=_unspecified, error=_unspecified):
+    if result is not _unspecified and error is not _unspecified:
         raise ValueError("Cannot have both result and error.")
 
     f = Future()
-    if result is not None:
+    if result is not _unspecified:
         resolve(f, result)
-    elif error is not None:
+    elif error is not _unspecified:
         reject(f, error)
     return f
 

--- a/txaio/tx.py
+++ b/txaio/tx.py
@@ -44,15 +44,17 @@ class FailedFuture(IFailedFuture):
 
 FailedFuture.register(Failure)
 
+_unspecified = object()
 
-def create_future(result=None, error=None):
-    if result is not None and error is not None:
+
+def create_future(result=_unspecified, error=_unspecified):
+    if result is not _unspecified and error is not _unspecified:
         raise ValueError("Cannot have both result and error.")
 
     f = Deferred()
-    if result is not None:
+    if result is not _unspecified:
         resolve(f, result)
-    elif error is not None:
+    elif error is not _unspecified:
         reject(f, error)
     return f
 


### PR DESCRIPTION
Ensure we get an already-resolved Future/Deferred if ``as_future`` is called with a method that immediately returns ``None``. Previously, the Future wouldn't be resolved at all.