### PR TITLE
Add failure_* methods and simplify IFailedFuture interface

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -45,8 +45,6 @@ Code like the following can then run on *either* system:
     txaio.reject(f1, RuntimeError("it failed"))
 
 
-See :ref:`restrictions` for limitations.
-
 .. toctree::
    :maxdepth: 3
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -38,9 +38,9 @@ methods on futures -- use *only* ``txaio`` methods to operate on them.
         print("Callback:", value)
 
     def eb(fail):
-        # fail will implement txaio.IFailedPromise
-        print("Errback:", fail)
-        fail.printTraceback()
+        # fail will implement txaio.IFailedFuture
+        print("Errback:", txaio.failure_message(fail))
+        print(txaio.failure_formatted_traceback(fail))
 
     f = txaio.create_future()
     txaio.add_callbacks(f, cb, eb)
@@ -113,6 +113,23 @@ only exists in the asyncio implementation.
 
 There is no ``inlineCallbacks`` or ``coroutine`` decorator
 support. Don't use these.
+
+
+Error Handling
+--------------
+
+In your ``errback``, you will receive a single arg which is an
+instance conforming to ``IFailedFuture``. This interface has only a
+single attribute: ``.value``, which is the Exception instance which
+caused the error. You can also use ``txaio.failure_*`` methods to
+operate on an ``IFailedFuture``:
+
+ - txaio.failure_message: returns a unicode error-message
+ - txaio.failure_traceback: returns a ``traceback`` object
+ - txaio.failure_formatted_traceback: returns a unicode formatted stack-trace
+
+You should **not** depend on *any* other attributes or methods of the
+instance you're given.
 
 
 Real Examples

--- a/test/test_errback.py
+++ b/test/test_errback.py
@@ -24,7 +24,6 @@
 #
 ###############################################################################
 
-from six import StringIO
 import txaio
 
 from util import run_once
@@ -49,13 +48,13 @@ def test_errback():
     assert len(errors) == 1
     assert isinstance(errors[0], txaio.IFailedFuture)
     assert exception == errors[0].value
-    assert type(exception) == errors[0].type
-    assert errors[0].tb is not None
-    tb = StringIO()
-    errors[0].printTraceback(file=tb)
-    assert 'RuntimeError' in tb.getvalue()
-    assert 'it failed' in tb.getvalue()
-    assert errors[0].getErrorMessage() == 'it failed'
+    assert txaio.failure_traceback(errors[0]) is not None
+
+    tb = txaio.failure_format_traceback(errors[0])
+
+    assert 'RuntimeError' in tb
+    assert 'it failed' in tb
+    assert txaio.failure_message(errors[0]) == 'it failed'
     assert 'it failed' in str(errors[0])
 
 
@@ -77,13 +76,11 @@ def test_errback_without_except():
 
     assert len(errors) == 1
     assert isinstance(errors[0], txaio.IFailedFuture)
-    assert exception == errors[0].value
-    assert type(exception) == errors[0].type
-    tb = StringIO()
-    errors[0].printTraceback(file=tb)
-    assert 'RuntimeError' in tb.getvalue()
-    assert 'it failed' in tb.getvalue()
-    assert errors[0].getErrorMessage() == 'it failed'
+    tb = txaio.failure_format_traceback(errors[0])
+
+    assert 'RuntimeError' in tb
+    assert 'it failed' in tb
+    assert txaio.failure_message(errors[0]) == 'it failed'
     assert 'it failed' in str(errors[0])
 
 
@@ -104,13 +101,11 @@ def test_errback_plain_exception():
 
     assert len(errors) == 1
     assert isinstance(errors[0], txaio.IFailedFuture)
-    assert exception == errors[0].value
-    assert type(exception) == errors[0].type
-    tb = StringIO()
-    errors[0].printTraceback(file=tb)
-    assert 'RuntimeError' in tb.getvalue()
-    assert 'it failed' in tb.getvalue()
-    assert errors[0].getErrorMessage() == 'it failed'
+    tb = txaio.failure_format_traceback(errors[0])
+
+    assert 'RuntimeError' in tb
+    assert 'it failed' in tb
+    assert txaio.failure_message(errors[0]) == 'it failed'
     assert 'it failed' in str(errors[0])
 
 
@@ -148,13 +143,11 @@ def test_errback_reject_no_args():
     assert len(errors) == 1
     assert isinstance(errors[0], txaio.IFailedFuture)
     assert exception == errors[0].value
-    assert type(exception) == errors[0].type
-    assert errors[0].tb is not None
-    tb = StringIO()
-    errors[0].printTraceback(file=tb)
-    assert 'RuntimeError' in tb.getvalue()
-    assert 'it failed' in tb.getvalue()
-    assert errors[0].getErrorMessage() == 'it failed'
+    tb = txaio.failure_format_traceback(errors[0])
+
+    assert 'RuntimeError' in tb
+    assert 'it failed' in tb
+    assert txaio.failure_message(errors[0]) == 'it failed'
     assert 'it failed' in str(errors[0])
 
 

--- a/txaio/__init__.py
+++ b/txaio/__init__.py
@@ -69,7 +69,11 @@ __all__ = (
     'add_callbacks',   # add callback and/or errback
     'gather',          # return a Future waiting for several other Futures
 
-    'IFailedFuture',            # describes API for arg to errback()s
+    'failure_message',    # a printable error-message from a IFailedFuture
+    'failure_traceback',  # returns a traceback instance from an IFailedFuture
+    'failure_format_traceback',  # a string, the formatted traceback
+
+    'IFailedFuture',             # describes API for arg to errback()s
 )
 
 

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -27,11 +27,13 @@
 from __future__ import absolute_import, print_function
 
 import sys
-import traceback
 import functools
+import traceback
 
 from txaio.interfaces import IFailedFuture
 from txaio import _Config
+
+import six
 
 try:
     import asyncio
@@ -76,36 +78,45 @@ class FailedFuture(IFailedFuture):
         self._traceback = traceback
 
     @property
-    def type(self):
-        return self._type
-
-    @property
     def value(self):
         return self._value
 
-    @property
-    def tb(self):
-        return self._traceback
-
-    def printTraceback(self, file=None):
-        """
-        Prints the complete traceback to stderr, or to the provided file
-        """
-        # print_exception handles None for file
-        traceback.print_exception(self.type, self.value, self._traceback,
-                                  file=file)
-
-    def getErrorMessage(self):
-        """
-        Returns the str() of the underlying exception.
-        """
-        return str(self.value)
-
     def __str__(self):
-        return self.getErrorMessage()
+        return str(self.value)
 
 
 # API methods for txaio, exported via the top-level __init__.py
+
+
+def failure_message(fail):
+    """
+    :param fail: must be an IFailedFuture
+    returns a unicode error-message
+    """
+    return str(fail._value)
+
+
+def failure_traceback(fail):
+    """
+    :param fail: must be an IFailedFuture
+    returns a traceback instance
+    """
+    return fail._traceback
+
+
+def failure_format_traceback(fail):
+    """
+    :param fail: must be an IFailedFuture
+    returns a string
+    """
+    f = six.StringIO()
+    traceback.print_exception(
+        fail._type,
+        fail.value,
+        fail._traceback,
+        file=f,
+    )
+    return f.getvalue()
 
 
 _unspecified = object()

--- a/txaio/interfaces.py
+++ b/txaio/interfaces.py
@@ -40,16 +40,14 @@ class IFailedFuture(object):
     An instance implementing this interface is given to any
     ``errback`` callables you provde via :meth:`txaio.add_callbacks`
 
-    It is a subset of Twisted's Failure interface, because on Twisted
-    backends it actually *is* a Failure.
-    """
+    In your errback you can extract information from an IFailedFuture
+    with :meth:`txaio.failure_message` and
+    :meth:`txaio.failure_traceback` or use ``.value`` to get the
+    Exception instance.
 
-    @abc.abstractproperty
-    def type(self):
-        """
-        The type of the exception. Same as the first item returned from
-        ``sys.exc_info()``
-        """
+    Depending on other details or methods will probably cause
+    incompatibilities between asyncio and Twisted.
+    """
 
     @abc.abstractproperty
     def value(self):
@@ -57,30 +55,3 @@ class IFailedFuture(object):
         An actual Exception instance. Same as the second item returned from
         ``sys.exc_info()``
         """
-
-    @abc.abstractproperty
-    def tb(self):
-        """
-        A traceback object from the exception. Same as the third item
-        returned from ``sys.exc_info()``
-        """
-
-    @abc.abstractmethod
-    def printTraceback(self, file=None):
-        """
-        Prints the exception and its traceback to the given ``file``. If
-        that is ``None`` (the default) then it is printed to
-        ``sys.stderr``.
-
-        XXX this is camelCase because Twisted is; can we change somehow?
-        """
-
-    @abc.abstractmethod
-    def getErrorMessage(self):
-        """
-        Return a string describing the error.
-
-        XXX this is camelCase because Twisted is; can we change somehow?
-        """
-
-    # XXX anything else make sense? Do we ape the *entire* Failure API?

--- a/txaio/tx.py
+++ b/txaio/tx.py
@@ -32,17 +32,42 @@ from twisted.internet.interfaces import IReactorTime
 from txaio.interfaces import IFailedFuture
 from txaio import _Config
 
+import six
+
 using_twisted = True
 using_asyncio = False
 
 config = _Config()
 
 
-class FailedFuture(IFailedFuture):
-    pass
+IFailedFuture.register(Failure)
 
 
-FailedFuture.register(Failure)
+def failure_message(fail):
+    """
+    :param fail: must be an IFailedFuture
+    returns a unicode error-message
+    """
+    return fail.getErrorMessage()
+
+
+def failure_traceback(fail):
+    """
+    :param fail: must be an IFailedFuture
+    returns a traceback instance
+    """
+    return fail.tb
+
+
+def failure_format_traceback(fail):
+    """
+    :param fail: must be an IFailedFuture
+    returns a string
+    """
+    f = six.StringIO()
+    fail.printTraceback(file=f)
+    return f.getvalue()
+
 
 _unspecified = object()
 


### PR DESCRIPTION
I also added a ``failure_formatted_traceback`` for simplicity (and so "format stack trace" code wasn't just stuck in the txaio tests).