### PR TITLE
Newlines back in messages

### DIFF
--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -43,7 +43,7 @@ class TestHandler(BytesIO):
     def messages(self):
         # Because we print the \n after, there will always be an empty
         # 'message', so just don't include it.
-        return self.getvalue().split(os.sep.encode('ascii'))[:-1]
+        return self.getvalue().split(os.linesep.encode('ascii'))[:-1]
 
 
 @pytest.fixture(scope='session')

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -147,7 +147,7 @@ class _TxaioFileHandler(logging.Handler, object):
         msg = u'{0} {1}{2}'.format(
             dt.strftime("%Y-%m-%dT%H:%M:%S%z"),
             fmt.format(**record.args),
-            os.sep
+            os.linesep
         )
         if self._encode:
             msg = msg.encode('utf8')

--- a/txaio/tx.py
+++ b/txaio/tx.py
@@ -216,7 +216,7 @@ class _LogObserver(object):
             msg = u'{0} {1}{2}'.format(
                 formatTime(event["log_time"]),
                 failure_format_traceback(event['log_failure']),
-                os.sep
+                os.linesep,
             )
             if self._encode:
                 msg = msg.encode('utf8')
@@ -228,7 +228,7 @@ class _LogObserver(object):
                 msg = u'{0} {1}{2}'.format(
                     formatTime(event["log_time"]),
                     formatEvent(event),
-                    os.sep
+                    os.linesep,
                 )
                 if self._encode:
                     msg = msg.encode('utf8')


### PR DESCRIPTION
This again formats stack-traces as one would expect (i.e. on multiple lines).