### PR TITLE
Detect generator-function given to as_future()

### DIFF
--- a/txaio/tx.py
+++ b/txaio/tx.py
@@ -321,18 +321,19 @@ def create_future(result=_unspecified, error=_unspecified):
     return f
 
 
-# maybe delete, just use create_future()
 def create_future_success(result):
     return succeed(result)
 
 
-# maybe delete, just use create_future()
 def create_future_error(error=None):
     return fail(create_failure(error))
 
 
-# maybe rename to call()?
 def as_future(fun, *args, **kwargs):
+    if inspect.isgeneratorfunction(fun):
+        msg = "Function '{0}.{1}' is a generator function; did you miss @inlineCallbacks?".format(
+            fun.__module__, fun.func_name)
+        raise RuntimeError(msg)
     return maybeDeferred(fun, *args, **kwargs)
 
 


### PR DESCRIPTION
What do you think about this?

I've done this a few times myself, and I can't think of any reason that you'd actually want to pass a generator-function to ``as_future``.

I suppose it *could* be true that you'd really actually want to have a Deferred fire and return a generator-object, but I suspect that case is very, very rare vs. forgetting to decorate with @inlineCallbacks? And if you really did want to do that, you still could (albeit a bit awkward):

```python
def actually_generator():
    yield 42
    yield 9000
txaio.as_future(lambda: actually_generator())  # no error; Deferred will resolve w/ generator-object
txaio.as_future(actually_generator)  # will give error about @inlineCallbacks
```

If this seems like a good idea, I'll also add one for the ``aio.py`` implementation (except it will say ``@asyncio.coroutine`` instead of inlineCallbacks).