### PR TITLE
Remove targeting .coverage file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ after_success:
   # since we use --parallel-mode to coverage inside Tox we use
   # "coverage combine" so the filename is always ".coverage"
   - coverage combine
-  - codecov --file .coverage
+  - codecov
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Codecov needs to run `coverage xml` on the `.coverage` file in order to build the report.

Thank you!